### PR TITLE
Changed yaml.load() to yaml.safe_load()

### DIFF
--- a/pytic/pytic.py
+++ b/pytic/pytic.py
@@ -292,7 +292,7 @@ class PyTic_Settings(object):
 
     def load_config(self, config_file):
         with open(config_file, 'r') as ymlfile:
-            cfg = yaml.load(ymlfile)
+            cfg = yaml.safe_load(ymlfile)
 
         cfg_settings = cfg['tic_settings']
 


### PR DESCRIPTION
Solved issue #5 by changing yaml.load() to yaml.safe_load() to avoid the yaml loader arg requirement.