### PR TITLE
Fix PyYAML 6+ compatibility by using SafeLoader

### DIFF
--- a/pytic/pytic.py
+++ b/pytic/pytic.py
@@ -292,7 +292,7 @@ class PyTic_Settings(object):
 
     def load_config(self, config_file):
         with open(config_file, 'r') as ymlfile:
-            cfg = yaml.load(ymlfile)
+            cfg = yaml.load(ymlfile, Loader=yaml.SafeLoader) 
 
         cfg_settings = cfg['tic_settings']
 


### PR DESCRIPTION
## Summary
This PR updates `pytic.py` to use `yaml.SafeLoader` when loading YAML configuration files. 

## Background
- In PyYAML < 5.1, `yaml.load()` without a Loader argument was allowed.
- In PyYAML ≥ 6.0 (now required for Python 3.12+), `yaml.load()` requires an explicit Loader.
- Without this change, importing configurations with PyTic raises:

TypeError: load() missing 1 required positional argument: 'Loader'

## Fix
Replaced:
```python
cfg = yaml.load(ymlfile)
```
with:
```python
cfg = yaml.load(ymlfile, Loader=yaml.SafeLoader)
```
## Benefits
Restores compatibility with PyYAML 6+ and Python 3.12+

Backward compatible with older PyYAML

Prevents runtime errors for users on modern environments

## Notes
This is a minimal change, does not affect any existing functionality, and follows PyYAML’s recommendation for safe parsing.