### PR TITLE
Fix for pyyaml API change

### DIFF
--- a/pytic/pytic.py
+++ b/pytic/pytic.py
@@ -292,7 +292,7 @@ class PyTic_Settings(object):
 
     def load_config(self, config_file):
         with open(config_file, 'r') as ymlfile:
-            cfg = yaml.load(ymlfile)
+            cfg = yaml.load(ymlfile, yaml.SafeLoader)
 
         cfg_settings = cfg['tic_settings']
 

--- a/pytic/pytic.py
+++ b/pytic/pytic.py
@@ -292,7 +292,10 @@ class PyTic_Settings(object):
 
     def load_config(self, config_file):
         with open(config_file, 'r') as ymlfile:
-            cfg = yaml.load(ymlfile, yaml.SafeLoader)
+            if yaml.__version__.split('.')[:2] < ['5', '1']:
+                cfg = yaml.load(ymlfile)
+            else:
+                cfg = yaml.load(ymlfile, yaml.SafeLoader)
 
         cfg_settings = cfg['tic_settings']
 

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ with open('README.md') as f:
 
 setup(
     name = "PyTic",
-    version = "0.0.4",
+    version = "0.0.5",
     author = "Daniel Castelli",
     author_email = "danc@alleninstitute.org",
     description = "An object-oriented Python wrapper for Pololu Tic Stepper Controllers.",


### PR DESCRIPTION
This makes pytic usable with pyyaml >= 5.1 and retains support for older versions.

closes #5 
closes #12 